### PR TITLE
Fix missing parent_rev in Upload(Stream) overloads

### DIFF
--- a/DropNetRT/Client.Files.cs
+++ b/DropNetRT/Client.Files.cs
@@ -398,7 +398,20 @@ namespace DropNetRT
         /// <returns></returns>
         public async Task<Metadata> Upload(string path, string filename, Stream stream, CancellationToken cancellationToken)
         {
-            var request = MakeUploadPutRequest(path, filename);
+            return await Upload(path, filename, stream, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Uploads a streamed data to a Dropbox folder
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="filename"></param>
+        /// <param name="stream"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<Metadata> Upload(string path, string filename, Stream stream, string parentRevision, CancellationToken cancellationToken)
+        {
+            var request = MakeUploadPutRequest(path, filename, parentRevision);
 
             var content = new StreamContent(stream);
 

--- a/DropNetRT/Client.Helpers.cs
+++ b/DropNetRT/Client.Helpers.cs
@@ -195,13 +195,16 @@ namespace DropNetRT
             return request;
         }
 
-        private HttpRequest MakeUploadPutRequest(string path, string filename)
+        private HttpRequest MakeUploadPutRequest(string path, string filename, string parentRevision)
         {
             var requestUrl = MakeRequestString(string.Format("1/files_put/{0}/{1}/{2}", Root, path.CleanPath(), filename), ApiType.Content);
 
             var request = new HttpRequest(HttpMethod.Put, requestUrl);
 
             _oauthHandler.Authenticate(request);
+
+            if (!string.IsNullOrEmpty(parentRevision))
+                request.AddParameter("parent_rev", parentRevision);
 
             return request;
         }


### PR DESCRIPTION
The Upload(byte[]) overloads don't support non-ASCII filename characters because the filename is specified in the Content-Disposition header which is always ASCII-encoded.

The Upload(Stream) overloads fix this problem because they use files_put, but are missing the option to specify the parent revision that the third Upload(byte[]) overload has.

I've therefore added a third Upload(Stream) overload, as per Upload(byte[]), to fix this.