### PR TITLE
Make chunked upload methods public

### DIFF
--- a/DropNetRT/Client.Helpers.cs
+++ b/DropNetRT/Client.Helpers.cs
@@ -227,13 +227,16 @@ namespace DropNetRT
             return request;
         }
 
-        private HttpRequest MakeChunkedUploadCommitRequest(string path, string filename, string uploadId)
+        private HttpRequest MakeChunkedUploadCommitRequest(string path, string filename, string parentRevision, string uploadId)
         {
             var requestUrl = MakeRequestString(string.Format("1/commit_chunked_upload/auto/{0}{2}{1}", path.CleanPath(), filename, path.CleanPath().Length > 0 ? "/" : ""), ApiType.Content);
 
             var request = new HttpRequest(HttpMethod.Post, requestUrl);
 
             request.AddParameter("upload_id", uploadId);
+
+            if (!string.IsNullOrEmpty(parentRevision))
+                request.AddParameter("parent_rev", parentRevision);
 
             _oauthHandler.Authenticate(request);
 


### PR DESCRIPTION
... so that applications can implement their own pause / resume code.

This maintains the existing `ChunkedUpload` method signature, and additionally exposes the underlying chunked upload methods.

I expect that many applications want to control chunked uploads, in particular to support resuming after an application restart or internet connectivity problem.
